### PR TITLE
[COR-916] Check if database already exists before trying to create.

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -144,9 +144,12 @@ func (a *Adapter) createDatabase() error {
 	}
 
 	if a.driverName == "postgres" || a.driverName == "pq-timeouts" {
-		test := db.Exec("SELECT 1 FROM pg_database WHERE datname = 'casbin'")
-		if test.Error != nil {
-
+		//COR-916: If database already exists, just exit. Users without permissions to create database
+		//will fail on CREATE DATABASE call further on down.
+		casbindb := db.Exec("SELECT 1 FROM pg_database WHERE datname = 'casbin'")
+		if casbindb.Error == nil && casbindb.RowsAffected == 1 {
+			db.Close()
+			return nil
 		}
 
 		if err = db.Exec("CREATE DATABASE casbin").Error; err != nil {

--- a/adapter.go
+++ b/adapter.go
@@ -144,6 +144,11 @@ func (a *Adapter) createDatabase() error {
 	}
 
 	if a.driverName == "postgres" || a.driverName == "pq-timeouts" {
+		test := db.Exec("SELECT 1 FROM pg_database WHERE datname = 'casbin'")
+		if test.Error != nil {
+
+		}
+
 		if err = db.Exec("CREATE DATABASE casbin").Error; err != nil {
 			// 42P04 is	duplicate_database
 			if err.(*pq.Error).Code == "42P04" {


### PR DESCRIPTION
Users without permissions to create database would always fail, even if database already exists. This change will fix that.